### PR TITLE
Stricter feature col selection

### DIFF
--- a/example_model.py
+++ b/example_model.py
@@ -18,7 +18,7 @@ def main(output_dir=None):
     tournament = pd.read_csv('example_tournament_data_yahoo.csv')
     spinner.succeed()
 
-    feature_names = train.filter(like='feature_').columns.to_list()
+    feature_names = [c for c in train if c.startswith("feature_")]
 
     spinner.start('Training model')
     model = GradientBoostingRegressor(subsample=0.1)


### PR DESCRIPTION
`.filter(like='feature)')` was adding the `factor_feature_neutral_target_20d` column to the list of feature columns, causing all 20D rounds to be dropped when `tournament.dropna(subset=['target'] + feature_names)` was called